### PR TITLE
Make hashes consistent with Python

### DIFF
--- a/client.go
+++ b/client.go
@@ -185,8 +185,8 @@ func (t client) Ping() error {
 func (t client) hashKey(key string) string {
 	if t.hashKeys {
 		h := sha1.New()
-		s := h.Sum([]byte(key))
-		return fmt.Sprintf("%x", s)
+		io.WriteString(h, key)
+		return fmt.Sprintf("%x", h.Sum(nil))
 	}
 	return key
 }


### PR DESCRIPTION
The way the pooled client was hashing was not consistent with Python hashes.

Here's the hash from Python--
```
In [11]: hashlib.sha1("Hello there").hexdigest()
Out[11]: '726c76553e1a3fdea29134f36e6af2ea05ec5cce'
```

The difference in the hash in Go can be found here - https://play.golang.org/p/LjERtzJ8_t